### PR TITLE
Add observations_to_dataframe

### DIFF
--- a/mpcq/tests/test_utils.py
+++ b/mpcq/tests/test_utils.py
@@ -1,0 +1,43 @@
+import decimal
+
+import pandas as pd
+
+from mpcq.observation import Observation, ObservationStatus
+from mpcq.utils import observations_to_dataframe
+
+
+def test_observations_to_dataframe():
+
+    observation = Observation(
+        mpc_id=1000,
+        status=ObservationStatus.Published,
+        obscode="I41",
+        filter_band="R",
+        unpacked_provisional_designation="2022 AJ2",
+        timestamp="2021-01-01T00:00:00.000",
+        ra=decimal.Decimal(1.0),
+        ra_rms=decimal.Decimal(0.001),
+        dec=decimal.Decimal(-10.0),
+        dec_rms=decimal.Decimal(0.004),
+        mag=decimal.Decimal(20.0),
+        mag_rms=decimal.Decimal(0.1),
+    )
+
+    desired_df = pd.DataFrame(
+        {
+            "mpc_id": [1000],
+            "status": ["Published"],
+            "obscode": ["I41"],
+            "filter_band": ["R"],
+            "unpacked_provisional_designation": ["2022 AJ2"],
+            "timestamp": ["2021-01-01T00:00:00.000"],
+            "ra": [decimal.Decimal(1.0)],
+            "ra_rms": [decimal.Decimal(0.001)],
+            "dec": [decimal.Decimal(-10.0)],
+            "dec_rms": [decimal.Decimal(0.004)],
+            "mag": [decimal.Decimal(20.0)],
+            "mag_rms": [decimal.Decimal(0.1)],
+        }
+    )
+
+    pd.testing.assert_frame_equal(observations_to_dataframe([observation]), desired_df)

--- a/mpcq/utils.py
+++ b/mpcq/utils.py
@@ -1,0 +1,28 @@
+from dataclasses import asdict
+from typing import List
+
+import pandas as pd
+
+from .observation import Observation
+
+
+def observations_to_dataframe(observations: List[Observation]) -> pd.DataFrame:
+    """
+    Convert a list of Observation objects to a pandas DataFrame.
+
+    Parameters
+    ----------
+    observations : List[Observation]
+        The observations to convert.
+
+    Returns
+    -------
+    observations : `~pd.DataFrame`
+    """
+    data = [asdict(obs) for obs in observations]
+
+    # Convert ObservationStatus objects to strings.
+    for row in data:
+        row["status"] = row["status"].name
+
+    return pd.DataFrame(data)


### PR DESCRIPTION
Simple utility to convert a list of observations to a dataframe (which is useful for analysis). @spenczar, looks like you might have been considering to do something similar since `pandas` was already part of the requirements so please close this if you have it somewhere already. 

I'm going to follow this up with a new query to pull an object's submission history. 