### PR TITLE
Add utilities for pulling mpc orbits

### DIFF
--- a/mpcq/client.py
+++ b/mpcq/client.py
@@ -343,7 +343,6 @@ class MPCObservationsClient:
             chunk_stmt = stmt.limit(chunk_size).offset(offset)
             result = self._dbconn.execute(chunk_stmt)
             chunk = orbits_from_query_result(result)
-            # if not chunk:
             if not chunk:
                 break
             yield chunk

--- a/mpcq/orbit.py
+++ b/mpcq/orbit.py
@@ -1,0 +1,88 @@
+import logging
+from typing import Iterator
+import sqlalchemy as sq
+
+import numpy as np
+
+from adam_core.coordinates.cometary import CometaryCoordinates
+from adam_core.coordinates.covariances import (
+    CoordinateCovariances,
+    sigmas_to_covariances,
+)
+from adam_core.coordinates.origin import Origin
+from adam_core.time import Timestamp
+from adam_core.orbits import Orbits
+from adam_core.orbits.query.sbdb import _convert_SBDB_covariances
+
+logger = logging.getLogger(__name__)
+
+
+def orbits_from_query_result(
+    results: sq.engine.cursor.LegacyCursorResult
+) -> Orbits:
+    """
+    Iterates through a query result and coerces the results in an
+    adam_core Orbits object
+
+    Covariance is computed from the orbital element sigmas
+    """
+
+    # covariances_mpc = np.zeros((chunk_size, 6, 6), dtype=np.float64)
+    covariances_list = []
+    columns = results.keys()
+    result_dict = {col: [] for col in columns}
+
+    for i, result in enumerate(results):
+        # We occasionally have null orbits in the database, so we want to skip those
+        if result['epoch_mjd'] is None:
+            continue
+        for col in columns:
+            # if null we want to skip this iteration
+            if col == "tp":
+                result_dict[col].append(
+                    Timestamp.from_mjd([result[col]], scale="tdb").mjd()[0].as_py()
+                )
+            else:
+                result_dict[col].append(result[col])
+
+        sigmas = np.ma.array(
+            [
+                [
+                    result["e_sig"],
+                    result["q_sig"],
+                    result["tp_sig"],
+                    result["raan_sig"],
+                    result["ap_sig"],
+                    result["i_sig"],
+                ]
+            ]
+        )
+        covariances_list.append(sigmas_to_covariances(sigmas)[0])
+
+    covariances_mpc = np.zeros((len(covariances_list), 6, 6), dtype=np.float64)
+    for i in range(len(covariances_mpc)):
+        covariances_mpc[i, :, :] = sigmas_to_covariances(sigmas)[0]
+
+    covariances_cometary = _convert_SBDB_covariances(covariances_mpc)
+    times = Timestamp.from_mjd(result_dict["epoch_mjd"], scale="tdb")
+    origin = Origin.from_kwargs(code=["SUN" for i in range(len(times))])
+    frame = "ecliptic"
+    coordinates = CometaryCoordinates.from_kwargs(
+        time=times,
+        q=result_dict["q"],
+        e=result_dict["e"],
+        i=result_dict["i"],
+        raan=result_dict["raan"],
+        ap=result_dict["ap"],
+        tp=result_dict["tp"],
+        covariance=CoordinateCovariances.from_matrix(covariances_cometary),
+        origin=origin,
+        frame=frame,
+    )
+
+    orbit_ids = np.array([str(id) for id in result_dict["mpc_id"]])
+    object_ids = np.array(result_dict["provid"])
+
+    return Orbits.from_kwargs(
+        orbit_id=orbit_ids, object_id=object_ids, coordinates=coordinates.to_cartesian()
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,27 @@
 [project]
 name = "mpcq"
-dynamic = ["version"]
+dynamic = ["version", "readme"]
+requires-python = ">=3.9"
+
+dependencies = [
+    "adam_core @ git+https://git@github.com/B612-Asteroid-Institute/adam_core@2eb98c2a8ee5703cd9de8d37c1281aa7881be3fa#egg=adam_core", 
+    "sqlalchemy < 2", 
+    "pandas", 
+    "astropy", 
+    "quivr", 
+    "google-cloud-secret-manager", 
+    "cloud-sql-python-connector[pg8000]", 
+    "pg8000"
+]
+
+[project.optional-dependencies]
+tests = [
+    "pre-commit",
+    "pytest"
+]
 
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools", "wheel", "setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --all-extras
 #
-adam-core @ git+https://git@github.com/B612-Asteroid-Institute/adam_core@3411b9802713e45d394df9682c61b5402701d45d
+adam-core @ git+https://git@github.com/B612-Asteroid-Institute/adam_core@2eb98c2a8ee5703cd9de8d37c1281aa7881be3fa
 aiohttp==3.8.4
     # via cloud-sql-python-connector
 aiosignal==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --all-extras
 #
+adam-core @ git+https://git@github.com/B612-Asteroid-Institute/adam_core@3411b9802713e45d394df9682c61b5402701d45d
 aiohttp==3.8.4
     # via cloud-sql-python-connector
 aiosignal==1.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,8 @@ setup_requires =
     setuptools >= 45
     wheel
     setuptools_scm >= 6.2
-install_requires =
+install_requires =    
+    adam_core @ git+https://git@github.com/B612-Asteroid-Institute/adam_core@3411b9802713e45d394df9682c61b5402701d45d#egg=adam_core
     sqlalchemy < 2
     pandas
     astropy

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ setup_requires =
     wheel
     setuptools_scm >= 6.2
 install_requires =    
-    adam_core @ git+https://git@github.com/B612-Asteroid-Institute/adam_core@3411b9802713e45d394df9682c61b5402701d45d#egg=adam_core
+    adam_core @ git+https://git@github.com/B612-Asteroid-Institute/adam_core@2eb98c2a8ee5703cd9de8d37c1281aa7881be3fa#egg=adam_core
     sqlalchemy < 2
     pandas
     astropy


### PR DESCRIPTION
This adds a method on the client that retrieves all orbits from MPC, and yields them in chunks after converting them to adam_core `Orbits`

This might have been incorrect, but I included the covariances using the existing utility for querying SBDB, which generates them from the orbital element sigmas.   

I noticed after writing this that the MPC db also has the covariances (and cartesian state vector!) in the jsonb column (example linked)
[mpcorb.jsonb.json](https://github.com/B612-Asteroid-Institute/mpcq/files/13432588/mpcorb.jsonb.json).

Maybe it would be better to go off of these?


Additionally, this PR adds dependencies to pyproject.toml.
